### PR TITLE
Set env var for lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ commands:
     parameters:
       stage:
         type: string
+      help_request_api_url:
+        type: string
     steps:
       - *attach_workspace
       - checkout
@@ -74,7 +76,7 @@ commands:
           name: apply
           command: |
             cd infrastructure/<<parameters.stage>>
-            terraform apply -auto-approve
+            terraform apply -var api_url=<<parameters.help_request_api_url>> -auto-approve
 
 jobs:
   build-and-test:
@@ -105,16 +107,19 @@ jobs:
     steps:
       - terraform-init-then-apply:
           stage: "development"
+          help_request_api_url: $HELP_REQUEST_API_URL_DEVELOPEMENT
   terraform-init-and-apply-to-staging:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
           stage: "staging"
+          help_request_api_url: $HELP_REQUEST_API_URL_STAGINING
   terraform-init-and-apply-to-production:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
           stage: "production"
+          help_request_api_url: $HELP_REQUEST_API_URL_PRODUCTION
 
 
 

--- a/infrastructure/development/main.tf
+++ b/infrastructure/development/main.tf
@@ -18,7 +18,12 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+variable "api_url" {
+  type = string
+}
+
 module "all-resources" {
   source = "../shared"
   stage = "development"
+  api_url = var.api_url
 }

--- a/infrastructure/production/main.tf
+++ b/infrastructure/production/main.tf
@@ -18,7 +18,12 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+variable "api_url" {
+  type = string
+}
+
 module "all-resources" {
   source = "../shared"
   stage = "production"
+  api_url = var.api_url
 }

--- a/infrastructure/shared/main.tf
+++ b/infrastructure/shared/main.tf
@@ -22,6 +22,10 @@ variable "sg_for_lambda" {
             }
 }
 
+variable "api_url" {
+  type = string
+}
+
 variable "stage" {
   type = string
 }
@@ -54,6 +58,11 @@ resource "aws_lambda_function" "here-to-help-lambda" {
   vpc_config {
     subnet_ids         = lookup(var.subnet_ids_for_lambda, var.stage)
     security_group_ids = lookup(var.sg_for_lambda, var.stage)
+  }
+  environment {
+    variables = {
+      CV_19_RES_SUPPORT_V3_HELP_REQUESTS_URL = var.api_url
+    }
   }
 }
 

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -18,7 +18,12 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+variable "api_url" {
+  type = string
+}
+
 module "all-resources" {
   source = "../shared"
   stage = "staging"
+  api_url = var.api_url
 }


### PR DESCRIPTION
**What**
- Set env var for lambda using terraform and ci

**Why**
- The api url must be set as an env var for the lambda to be able to query the api

**Notes**
- N/A