### PR TITLE
refactor date parser

### DIFF
--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -1,17 +1,38 @@
+import datetime
+import re
+
 from dateutil import parser
 import numpy as np
 
 
-def parse_date_of_birth(date_of_birth, year_first=False, day_first=False):
-    dob_day = parser.parse(
-        date_of_birth,
-        yearfirst=year_first, dayfirst=day_first).day if date_of_birth else ''
-    dob_month = parser.parse(
-        date_of_birth,
-        yearfirst=year_first, dayfirst=day_first).month if date_of_birth else ''
-    dob_year = parser.parse(
-        date_of_birth,
-        yearfirst=year_first, dayfirst=day_first).year if date_of_birth else ''
+def manual_parse(date_string):
+    date_numbers_string = re.findall(r'\d+', date_string)
+    date_numbers_string = ''.join(date_numbers_string)
+
+    try:
+        date = datetime.datetime.strptime(date_numbers_string, "%Y%m%d")
+        return date
+    except ValueError:
+        pass
+
+    try:
+        date = datetime.datetime.strptime(date_numbers_string, "%d%m%Y")
+        return date
+    except ValueError:
+        pass
+
+    return parser.parse(date_string, dayfirst=True)
+
+
+def parse_date_of_birth(date_of_birth):
+    if not date_of_birth:
+        return "", "", ""
+
+    parsed_date = manual_parse(date_of_birth)
+
+    dob_day = parsed_date.day
+    dob_month = parsed_date.month
+    dob_year = parsed_date.year
 
     return dob_day, dob_month, dob_year
 

--- a/lib_src/lib/usecase/add_cev_requests.py
+++ b/lib_src/lib/usecase/add_cev_requests.py
@@ -14,7 +14,7 @@ class AddCEVRequests:
         for index, row in data_frame.iterrows():
 
             dob_day, dob_month, dob_year = parse_date_of_birth(
-                row.date_of_birth, day_first=True)
+                row.date_of_birth)
 
             metadata = {
                 "nsss_id": row["ID"]

--- a/lib_src/lib/usecase/add_contact_tracing_requests.py
+++ b/lib_src/lib/usecase/add_contact_tracing_requests.py
@@ -13,7 +13,7 @@ class AddContactTracingRequests:
             row = row.to_dict()
 
             dob_day, dob_month, dob_year = parse_date_of_birth(
-                row['Date of Birth'], day_first=True)
+                row['Date of Birth'])
 
             metadata = {
                 "first_symptomatic_at": row["First Symptomatic At"],

--- a/lib_src/lib/usecase/add_spl_requests.py
+++ b/lib_src/lib/usecase/add_spl_requests.py
@@ -13,7 +13,7 @@ class AddSPLRequests:
         for index, row in data_frame.iterrows():
 
             dob_day, dob_month, dob_year = parse_date_of_birth(
-                row.DateOfBirth, year_first=True)
+                row.DateOfBirth)
 
             metadata = {
                 "spl_id": row.Traced_NHSNUMBER

--- a/lib_src/tests/test_helpers.py
+++ b/lib_src/tests/test_helpers.py
@@ -1,4 +1,3 @@
-import pytest
 from faker import Faker
 from lib_src.lib.helpers import parse_date_of_birth, case_note_needs_an_update
 
@@ -8,11 +7,29 @@ class TestParseDateOfBirth:
     def test_year_first_no_separators(self):
         test_date = '19830502'
         dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, year_first=True)
+            test_date)
 
         assert dob_day == 2
         assert dob_month == 5
         assert dob_year == 1983
+
+    def test_recent_year_first_no_separators(self):
+        test_date = '20020220'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
+
+        assert dob_day == 20
+        assert dob_month == 2
+        assert dob_year == 2002
+
+    def test_recent_day_first_no_separators(self):
+        test_date = '20122013'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
+
+        assert dob_day == 20
+        assert dob_month == 12
+        assert dob_year == 2013
 
     def test_year_first_with_separators(self):
         test_date = '1983-05-02'
@@ -22,19 +39,45 @@ class TestParseDateOfBirth:
         assert dob_month == 5
         assert dob_year == 1983
 
-    def test_day_first_with_separators(self):
-        test_date = '11/10/1989'
+    def test_day_first_with_slash_separators(self):
         dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, day_first=True)
+            '03/10/1989')
+
+        assert dob_day == 3
+        assert dob_month == 10
+        assert dob_year == 1989
+
+    def test_day_first_with_dot_separators(self):
+        test_date = '11.10.1989'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
 
         assert dob_day == 11
         assert dob_month == 10
         assert dob_year == 1989
 
+    def test_day_first_with_space_separators(self):
+        test_date = '11 10 1989'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
+
+        assert dob_day == 11
+        assert dob_month == 10
+        assert dob_year == 1989
+
+    def test_day_first_with_separators(self):
+        test_date = '1989-11-10'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
+
+        assert dob_day == 10
+        assert dob_month == 11
+        assert dob_year == 1989
+
     def test_empty_string(self):
         test_date = ''
         dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, day_first=True)
+            test_date)
 
         assert dob_day == ''
         assert dob_month == ''
@@ -43,25 +86,16 @@ class TestParseDateOfBirth:
     def test_undefined(self):
         test_date = None
         dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, day_first=True)
+            test_date)
 
         assert dob_day == ''
         assert dob_month == ''
         assert dob_year == ''
 
-    def test_short_year(self):
-        test_date = '200596'
-        dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, day_first=True)
-
-        assert dob_day == 20
-        assert dob_month == 5
-        assert dob_year == 1996
-
     def test_short_year_year_first(self):
-        test_date = '020520'
+        test_date = '20020520'
         dob_day, dob_month, dob_year = parse_date_of_birth(
-            test_date, year_first=True)
+            test_date)
 
         assert dob_day == 20
         assert dob_month == 5


### PR DESCRIPTION
refactoring date parser to be smarter about detecting date formats with the following steps:
- grab all the numbers from the date string (this removes any dividers from the string)
- attempt to parse the date in YYYY MM DD format and return if successful 
- attempt to parse the date in DD MM YYYY format and return if successful 
- if both fail, parse using the `dateutil.parser` with the day first because the default format for it is American and hope for the best (in tests I've not see it fall back to this but you never know 🤷‍♀️)