### PR TITLE
Feature/dont process unidentifiable rows

### DIFF
--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -73,7 +73,7 @@ def resident_is_identifiable(help_request):
     if help_request.get('DobDay') and help_request.get('DobMonth') and help_request.get('DobYear'):
         return True
 
-    if help_request.get('ContactTelephoneNumber') or help_request.get('ContactMobileNumber') or help_request.get('EmailAddress'):
+    if help_request.get('Uprn') or help_request.get('ContactTelephoneNumber') or help_request.get('ContactMobileNumber') or help_request.get('EmailAddress'):
         return True
 
     return False

--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -64,19 +64,15 @@ def resident_is_identifiable(help_request):
     if help_request.get('NhsNumber'):
         return True
 
-    if not help_request.get('FirstName') or not help_request.get('LastName'):
-        return False
+    if help_request.get('FirstName') and help_request.get('LastName'):
+        match_fields = ['NhsCtasId', 'Uprn', 'ContactTelephoneNumber', 'ContactMobileNumber', 'EmailAddress']
 
-    if help_request.get('NhsCtasId'):
-        return True
-
-    if help_request.get('DobDay') and help_request.get('DobMonth') and help_request.get('DobYear'):
-        return True
-
-    if help_request.get('Uprn') or help_request.get('ContactTelephoneNumber') or help_request.get('ContactMobileNumber') or help_request.get('EmailAddress'):
-        return True
+        if all(help_request.get(field) for field in ['DobDay', 'DobMonth', 'DobYear']) or\
+                any(help_request.get(field) for field in match_fields):
+            return True
 
     return False
+
 
 def clean_data(columns, data_frame):
     for i in columns:

--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -36,6 +36,7 @@ def parse_date_of_birth(date_of_birth):
 
     return dob_day, dob_month, dob_year
 
+
 def concatenate_address(address_line_1, house_number):
     if not address_line_1:
         return house_number
@@ -48,6 +49,7 @@ def concatenate_address(address_line_1, house_number):
 
     return house_number + ' ' + address_line_1
 
+
 def case_note_needs_an_update(case_notes_on_request, new_case_note):
     if not case_notes_on_request:
         return True
@@ -57,6 +59,24 @@ def case_note_needs_an_update(case_notes_on_request, new_case_note):
                 return False
         return True
 
+
+def resident_is_identifiable(help_request):
+    if help_request.get('NhsNumber'):
+        return True
+
+    if not help_request.get('FirstName') or not help_request.get('LastName'):
+        return False
+
+    if help_request.get('NhsCtasId'):
+        return True
+
+    if help_request.get('DobDay') and help_request.get('DobMonth') and help_request.get('DobYear'):
+        return True
+
+    if help_request.get('ContactTelephoneNumber') or help_request.get('ContactMobileNumber') or help_request.get('EmailAddress'):
+        return True
+
+    return False
 
 def clean_data(columns, data_frame):
     for i in columns:

--- a/lib_src/lib/usecase/create_help_requests.py
+++ b/lib_src/lib/usecase/create_help_requests.py
@@ -1,3 +1,6 @@
+from lib_src.lib.helpers import resident_is_identifiable
+
+
 class CreateHelpRequest:
 
     def __init__(self, gateway):
@@ -8,6 +11,10 @@ class CreateHelpRequest:
         exceptions = []
         for help_request in help_requests:
             try:
+                if not resident_is_identifiable(help_request):
+                    result["unsuccessful_help_requests"].append(help_request)
+                    help_request['Error'] = "Help request was not uniquely identifiable"
+                    continue
                 response = self.gateway.create_help_request(help_request=help_request)
                 if "Error" in response:
                     help_request['Error'] = response["Error"]

--- a/lib_src/lib/usecase/create_help_requests.py
+++ b/lib_src/lib/usecase/create_help_requests.py
@@ -13,7 +13,7 @@ class CreateHelpRequest:
             try:
                 if not resident_is_identifiable(help_request):
                     result["unsuccessful_help_requests"].append(help_request)
-                    help_request['Error'] = "Help request was not uniquely identifiable"
+                    print("Help request was not uniquely identifiable and was skipped.")
                     continue
                 response = self.gateway.create_help_request(help_request=help_request)
                 if "Error" in response:

--- a/lib_src/lib/usecase/create_help_requests.py
+++ b/lib_src/lib/usecase/create_help_requests.py
@@ -13,7 +13,7 @@ class CreateHelpRequest:
             try:
                 if not resident_is_identifiable(help_request):
                     result["unsuccessful_help_requests"].append(help_request)
-                    print("Help request was not uniquely identifiable and was skipped.")
+                    print("WARNING: Help request was not uniquely identifiable and was skipped.")
                     continue
                 response = self.gateway.create_help_request(help_request=help_request)
                 if "Error" in response:

--- a/lib_src/tests/test_helpers.py
+++ b/lib_src/tests/test_helpers.py
@@ -1,5 +1,5 @@
 from faker import Faker
-from lib_src.lib.helpers import parse_date_of_birth, case_note_needs_an_update
+from lib_src.lib.helpers import parse_date_of_birth, case_note_needs_an_update, resident_is_identifiable
 from lib_src.lib.helpers import concatenate_address
 
 
@@ -173,3 +173,78 @@ class TestCaseNoteNeedsAnUpdate:
 
         result = case_note_needs_an_update(case_notes_on_request, new_note)
         assert result
+
+
+class TestCaseResidentIsIdentifiable:
+    def setup_method(self):
+        self.fake = Faker()
+
+    def test_has_nhs_number_returns_true(self):
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "DobDay": 12,
+            "DobMonth": 1,
+            "DobYear": 1985,
+            "ContactTelephoneNumber": "01234",
+            "ContactMobileNumber": "344",
+            "NhsNumber": "1231233",
+            "NhsCtasId": ""
+        })
+
+    def test_name_and_nhs_number_missing_returns_false(self):
+        assert resident_is_identifiable(help_request={
+            "FirstName": '',
+            "LastName": 'Zebra',
+            "DobDay": 12,
+            "DobMonth": 1,
+            "DobYear": 1985,
+            "ContactTelephoneNumber": "01234",
+            "ContactMobileNumber": "344",
+            "NhsNumber": "",
+            "NhsCtasId": ""
+        }) == False
+
+    def test_name_combined_with_other_key_fields_match_if_nhs_number_is_missing(self):
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra'
+        }) == False
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "DobDay": 12,
+            "DobMonth": 1,
+            "DobYear": 1985,
+        })
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "NhsCtasId": '1',
+        })
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "NhsCtasId": '1',
+        })
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "ContactTelephoneNumber": '13434',
+        })
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "ContactMobileNumber": '13434',
+        })
+
+        assert resident_is_identifiable(help_request={
+            "FirstName": 'Mr',
+            "LastName": 'Zebra',
+            "EmailAddress": 'mr@zebra.safari',
+        })

--- a/lib_src/tests/usecases/test_create_help_requests.py
+++ b/lib_src/tests/usecases/test_create_help_requests.py
@@ -13,8 +13,8 @@ def test_create_help_request():
     result = use_case.execute(help_requests=requests)
     assert result["created_help_request_ids"] == [1, 2]
     assert result["unsuccessful_help_requests"][0]["EmailAddress"] == "sample@example.com"
-    assert result["unsuccessful_help_requests"][0]["Error"] == "error message"
-    assert gateway.count == 3
+    assert result["unsuccessful_help_requests"][0]["Error"] == "Help request was not uniquely identifiable"
+    assert gateway.count == 2
 
 
 def test_create_help_request_with_error():
@@ -27,6 +27,7 @@ def test_create_help_request_with_error():
                       "LastName": "Doe",
                       "NhsNumber": "321"},
                      {"LastName": "Jones",
+                      "FirstName": "Smith",
                       "EmailAddress": "sample@example.com"}]
     use_case = CreateHelpRequest(gateway=gateway)
     initial_help_requests = []

--- a/lib_src/tests/usecases/test_create_help_requests.py
+++ b/lib_src/tests/usecases/test_create_help_requests.py
@@ -13,7 +13,6 @@ def test_create_help_request():
     result = use_case.execute(help_requests=requests)
     assert result["created_help_request_ids"] == [1, 2]
     assert result["unsuccessful_help_requests"][0]["EmailAddress"] == "sample@example.com"
-    assert result["unsuccessful_help_requests"][0]["Error"] == "Help request was not uniquely identifiable"
     assert gateway.count == 2
 
 


### PR DESCRIPTION
# What
Added a method to determine if a resident record is uniquely identifiable. Implemented before calling Create Help Request and logs a warning if it skips the record.

# Why
To prevent sending records to the HTH API that aren't usable (i.e. a resident isn't contactable) and would create duplicates if sent multiple times.

# Additional
Also added a 'Warning' metric that an AWS alarm will pick up. Duplicates the structure used for Errors but only sends once every 24 hours.