### PR TITLE
Added filtering by status report field. Has to be 'completed'.

### DIFF
--- a/lib_src/lib/usecase/add_self_isolation_requests.py
+++ b/lib_src/lib/usecase/add_self_isolation_requests.py
@@ -14,7 +14,10 @@ class AddSelfIsolationRequests:
         data_frame.insert(0, 'resident_id', '')
         data_frame.insert(0, 'cev_case_added_id', '')
 
-        for index, row in data_frame.iterrows():
+        for index, row in data_frame.iterrows():                        
+            if not self.is_self_isolation_request_completed(row):
+                continue
+
             if not self.is_self_isolation_request(row):
                 continue
 
@@ -115,3 +118,6 @@ class AddSelfIsolationRequests:
 
     def is_self_isolation_request(self, row):
         return row["LA Support Required"] == '1' or row["LA Support Letter Received"] == "1"
+
+    def is_self_isolation_request_completed(self, row):
+        return row["Status Report"].lower() == 'completed'


### PR DESCRIPTION
# What:
- Filtering of the input spreadsheet to allow only "completed" cases.

# Why:
- Doing this so that call handlers wouldn't have to do it by manually filtering the spreadsheet before dropping it into correct place.

# Notes:
- The filtering is done by checking the "Status Report" field, which can either be "completed" or "failed".
- Jira Ticket: [41](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=HTHD&modal=detail&selectedIssue=HTHD-41).