### PR TITLE
Corrected date comparison. Caused error with time appended.

### DIFF
--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -21,6 +21,12 @@ def manual_parse(date_string):
     except ValueError:
         pass
 
+    try:
+        date = datetime.datetime.strptime(date_numbers_string, "%Y%m%d%H%M%S")
+        return date
+    except ValueError:
+        pass
+
     return parser.parse(date_string, dayfirst=True)
 
 
@@ -67,7 +73,7 @@ def resident_is_identifiable(help_request):
     if help_request.get('FirstName') and help_request.get('LastName'):
         match_fields = ['NhsCtasId', 'Uprn', 'ContactTelephoneNumber', 'ContactMobileNumber', 'EmailAddress']
 
-        if all(help_request.get(field) for field in ['DobDay', 'DobMonth', 'DobYear']) or\
+        if all(help_request.get(field) for field in ['DobDay', 'DobMonth', 'DobYear']) or \
                 any(help_request.get(field) for field in match_fields):
             return True
 

--- a/lib_src/tests/test_helpers.py
+++ b/lib_src/tests/test_helpers.py
@@ -97,6 +97,15 @@ class TestParseDateOfBirth:
         assert dob_month == 2
         assert dob_year == 1950
 
+    def test_day_less_than_13(self):
+        test_date = '2021-06-08 00:00:00'
+        dob_day, dob_month, dob_year = parse_date_of_birth(
+            test_date)
+
+        assert dob_day == 8
+        assert dob_month == 6
+        assert dob_year == 2021
+
     def test_empty_string(self):
         test_date = ''
         dob_day, dob_month, dob_year = parse_date_of_birth(

--- a/lib_src/tests/usecases/test_add_self_isolation_requests.py
+++ b/lib_src/tests/usecases/test_add_self_isolation_requests.py
@@ -188,9 +188,9 @@ def test_only_rows_newer_than_seven_days_get_processed():
 
     data_frame = get_data_frame(la_support_letter_received=la_support_letter_received,
                                 la_support_required=la_support_required,
-                                date_tested=[invalid_date.strftime("%d/%m/%Y"),
+                                date_tested=[invalid_date.strftime("%d/%m/%Y %H:%M:%S"),
                                              invalid_edge_date.strftime("%d/%m/%Y"),
-                                             valid_edge_date.strftime("%d/%m/%Y")])
+                                             valid_edge_date.strftime("%d-%m-%Y")])
 
     use_case = AddSelfIsolationRequests(create_help_request, here_to_help_api)
     processed_data_frame = use_case.execute(data_frame=data_frame)


### PR DESCRIPTION
The date parsing method being used can swap the month/day around, but only if the day is 12 or less, otherwise it correctly identifies the month / day.

In addition, this only caused a problem when the time was added to the date being parsed.

We've added a test for this scenario as well as updating the date parsing to process date/time in this format.