### PR TITLE
Disable contact tracing pipeline

### DIFF
--- a/infrastructure/shared/main.tf
+++ b/infrastructure/shared/main.tf
@@ -250,7 +250,7 @@ resource "aws_cloudwatch_event_rule" "here-to-help-scheduled-event" {
   name                = "here-to-help-scheduled-event"
   description         = "Fires every one minutes"
   schedule_expression = "rate(16 minutes)"
-  is_enabled = true
+  is_enabled = false
 }
 
 resource "aws_cloudwatch_event_rule" "here-to-help-scheduled-event-SPL" {


### PR DESCRIPTION
Set scheduled event to disabled so that the CT pipeline doesn't get triggered