### PR TITLE
Processing of generic ingestions

### DIFF
--- a/lib_src/lib/main.py
+++ b/lib_src/lib/main.py
@@ -16,6 +16,8 @@ from os import getenv
 from os import path
 from .usecase.add_self_isolation_requests import AddSelfIsolationRequests
 from .usecase.process_self_isolation_calls import ProcessSelfIsolationCalls
+from .usecase.add_generic_ingestion_requests import AddGenericIngestionRequests
+from .usecase.process_generic_ingestion_calls import ProcessGenericIngestionCalls
 
 load_dotenv()
 
@@ -171,11 +173,20 @@ def self_isolation_lambda_handler(event, context):
 def generic_ingestion_lambda_handler(event, context):
     print('- -generic_ingestion_lambda_handler - -')
 
+    if getenv("ENV") == 'production':
+        print(' -- disabled on production -- ')
+        return
+
     here_to_help_gateway = HereToHelpGateway()
 
     create_help_request = CreateHelpRequest(gateway=here_to_help_gateway)
 
     key_file_location = path.relpath('lib/key_file.json')
+
+    add_generic_requests = AddGenericIngestionRequests(
+        create_help_request, here_to_help_gateway)
+
+    process_new_sheet_generic_calls = ProcessGenericIngestionCalls(add_generic_requests)
 
     google_drive_gateway = GoogleDriveGateway(key_file_location)
 
@@ -186,10 +197,15 @@ def generic_ingestion_lambda_handler(event, context):
     generic_ingestion_inbound_folder_id = getenv("GENERIC_INGESTION_INBOUND_FOLDER_ID")
     generic_ingestion_outbound_folder_id = getenv("GENERIC_INGESTION_OUTBOUND_FOLDER_ID")
 
-    files = google_drive_gateway.get_list_of_files(generic_ingestion_inbound_folder_id)
+    sheet_process = ProcessMultipleSheets(
+        google_drive_gateway, pygsheets_gateway)
 
-    print('Number of files found: ' + str(len(files)))
+    generic_ingestion_response = sheet_process.execute(
+        generic_ingestion_inbound_folder_id,
+        generic_ingestion_outbound_folder_id,
+        process_new_sheet_generic_calls
+    )
 
     return {
-        "body": len(files)
+        "body": json.dumps([generic_ingestion_response])
     }

--- a/lib_src/lib/main.py
+++ b/lib_src/lib/main.py
@@ -183,16 +183,16 @@ def generic_ingestion_lambda_handler(event, context):
 
     key_file_location = path.relpath('lib/key_file.json')
 
-    add_generic_requests = AddGenericIngestionRequests(
-        create_help_request, here_to_help_gateway)
-
-    process_new_sheet_generic_calls = ProcessGenericIngestionCalls(add_generic_requests)
-
     google_drive_gateway = GoogleDriveGateway(key_file_location)
 
     pygsheets_gateway = PygsheetsGateway(
         key_file_location
     )
+
+    add_generic_requests = AddGenericIngestionRequests(
+        create_help_request, here_to_help_gateway)
+
+    process_new_sheet_generic_calls = ProcessGenericIngestionCalls(add_generic_requests)
 
     generic_ingestion_inbound_folder_id = getenv("GENERIC_INGESTION_INBOUND_FOLDER_ID")
     generic_ingestion_outbound_folder_id = getenv("GENERIC_INGESTION_OUTBOUND_FOLDER_ID")

--- a/lib_src/lib/usecase/add_generic_ingestion_requests.py
+++ b/lib_src/lib/usecase/add_generic_ingestion_requests.py
@@ -1,0 +1,69 @@
+import datetime
+from ..helpers import parse_date_of_birth
+
+
+def is_valid_help_request_type(help_request_type):
+    return help_request_type == 'EUSS'
+
+
+class AddGenericIngestionRequests:
+    def __init__(self, create_help_request, here_to_help_api):
+        self.create_help_request = create_help_request
+        self.here_to_help_api = here_to_help_api
+
+    def execute(self, data_frame):
+        author = "Data Ingestion: Generic Ingestion"
+
+        data_frame.insert(0, 'help_request_id', '')
+        data_frame.insert(0, 'resident_id', '')
+
+        for index, row in data_frame.iterrows():
+            help_request_type = row['Help Request Type']
+
+            if not is_valid_help_request_type(help_request_type):
+                continue
+
+            dob_day, dob_month, dob_year = parse_date_of_birth(
+                row['d.o.b'])
+
+            metadata = {
+                "Author": author,
+                "generic_ingestion_id": help_request_type.replace(" ", "")
+            }
+
+            help_request = [
+                {
+                    "Metadata": metadata,
+                    "Postcode": row.Postcode.upper(),
+                    "AddressFirstLine": row['Address Line 1'],
+                    "AddressSecondLine": row['Address Line 2'],
+                    "AddressThirdLine": row.City,
+                    "FirstName": row['First name'].capitalize() if row['First name'] else '',
+                    "LastName": row['Surname'].capitalize() if row['Surname'] else '',
+                    "DobDay": f'{dob_day}',
+                    "DobMonth": f'{dob_month}',
+                    "DobYear": f'{dob_year}',
+                    "ContactTelephoneNumber": row['Phone number'],
+                    "EmailAddress": row.Email if '@' in row.Email else '',
+                    "CallbackRequired": True,
+                    "HelpNeeded": help_request_type
+                }]
+
+            response = self.create_help_request.execute(
+                help_requests=help_request)
+
+            if response['created_help_request_ids']:
+                help_request_id = response['created_help_request_ids'][0]
+
+                request = self.here_to_help_api.get_help_request(
+                    help_request_id)
+
+                resident_id = request["ResidentId"]
+
+                data_frame.at[index, 'help_request_id'] = help_request_id
+                data_frame.at[index, 'resident_id'] = resident_id
+
+                print(
+                    f'Added Generic Ingestion record of type {help_request_type} {index + 1} of {len(data_frame)}: resident_id: {resident_id} help_request_id: {help_request_id}')
+
+        return data_frame

--- a/lib_src/lib/usecase/process_generic_ingestion_calls.py
+++ b/lib_src/lib/usecase/process_generic_ingestion_calls.py
@@ -1,0 +1,26 @@
+from ..helpers import clean_data
+
+
+class ProcessGenericIngestionCalls:
+    COLS = [
+        'First name',
+        'Surname',
+        'd.o.b',
+        'Help Request Type',
+        'Address Line 1',
+        'Address Line 2',
+        'City',
+        'Postcode',
+        'Email',
+        'Phone number'
+    ]
+
+    def __init__(self, add_generic_ingestion_requests):
+        self.add_generic_ingestion_requests = add_generic_ingestion_requests
+
+    def execute(self, data_frame):
+        data_frame = clean_data(columns=self.COLS, data_frame=data_frame)
+
+        processed_data_frame = self.add_generic_ingestion_requests.execute(data_frame)
+
+        return processed_data_frame

--- a/lib_src/tests/usecases/test_add_generic_ingestion_requests.py
+++ b/lib_src/tests/usecases/test_add_generic_ingestion_requests.py
@@ -1,0 +1,36 @@
+from lib_src.lib.usecase.add_generic_ingestion_requests import AddGenericIngestionRequests
+import pandas as pd
+from lib_src.tests.fakes.fake_create_help_request import FakeCreateHelpRequest
+from lib_src.tests.fakes.fake_here_to_help_gateway import FakeHereToHelpGateway
+import datetime
+
+
+def get_data_frame(help_request_type=['EUSS', 'unknown', 'EUSS']):
+    return pd.DataFrame({
+        'Postcode': ['BS3 3NG', 'BS4', 'BS5'],
+        'Address Line 1': ['A Road', 'A Road 2', 'A Road 3'],
+        'Address Line 2': ['Somewhere', 'Somewhere 2', 'Somewhere 3'],
+        'City': ['Hereford', 'Shire', 'Earth'],
+        'd.o.b': ['13/05/1985', '', ''],
+        'First name': ['Owen', 'Someone', 'Another'],
+        'Surname': ['Test', 'Surname', 'Lastname'],
+        'Phone number': ['000', '0123', '34'],
+        'Email': ['owen@test', 'notreal', ''],
+        'Help Request Type': help_request_type
+    })
+
+
+def test_only_known_help_request_type_rows_processed():
+    create_help_request = FakeCreateHelpRequest()
+
+    test_resident_id = 121231
+    here_to_help_api = FakeHereToHelpGateway(test_resident_id=test_resident_id)
+
+    data_frame = get_data_frame()
+
+    use_case = AddGenericIngestionRequests(create_help_request, here_to_help_api)
+    processed_data_frame = use_case.execute(data_frame=data_frame)
+
+    assert (processed_data_frame.at[0, 'help_request_id'] is not None)
+
+    assert len(create_help_request.received_help_requests) == 2


### PR DESCRIPTION
**What**

Added the processing of 'generic ingestion' data. At present this is for EUSS only, but will be extendable to add help request types and providing they use the same format, will ingest as the other type.

**Why**

Primarily to import EUSS data.

**Anything else?**

Due to help request de-duplication using CTAS ID or other contact-tracing specific IDs, this will not currently de-duplicate help requests. This will be raised as a separate ticket of slightly lower priority as the process can functional (albeit as a managed service) without. 