### PR TITLE
More logs to the CreateHelpRequestUseCase and HTH API create HR gateway method.

### DIFF
--- a/lib_src/lib/gateways/here_to_help_api.py
+++ b/lib_src/lib/gateways/here_to_help_api.py
@@ -29,8 +29,13 @@ class HereToHelpGateway:
             if response.status_code == 403:
                 print("Authentication error", response)
                 return {"Error": json.dumps(response.json())}
-
-            result = eval(response.text)
+            
+            if response.status_code != 201:
+                print("ERROR: Not a 201 response! Response: ", response.text)
+                raise Exception("Failure within an API.")
+            else:
+                result = response.json()
+                return result
 
         except HTTPError as err:
             print(
@@ -40,9 +45,7 @@ class HereToHelpGateway:
             return {"Error": err.msg}
         except Exception as err:
             print("Help request was not created", help_request)
-            return {"Error": err}
-
-        return result
+            return {"Error": str(err)}
 
     def get_help_request(self, help_request_id):
         try:

--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -68,17 +68,23 @@ def case_note_needs_an_update(case_notes_on_request, new_case_note):
 
 
 def resident_is_identifiable(help_request):
-    if help_request.get('NhsNumber'):
-        return True
-
-    if help_request.get('FirstName') and help_request.get('LastName'):
-        match_fields = ['NhsCtasId', 'Uprn', 'ContactTelephoneNumber', 'ContactMobileNumber', 'EmailAddress']
-
-        if all(help_request.get(field) for field in ['DobDay', 'DobMonth', 'DobYear']) or \
-                any(help_request.get(field) for field in match_fields):
+    try:
+        if help_request.get('NhsNumber'):
             return True
 
-    return False
+        if help_request.get('FirstName') and help_request.get('LastName'):
+            match_fields = ['NhsCtasId', 'Uprn', 'ContactTelephoneNumber', 'ContactMobileNumber', 'EmailAddress']
+
+            if all(help_request.get(field) for field in ['DobDay', 'DobMonth', 'DobYear']) or \
+                    any(help_request.get(field) for field in match_fields):
+                return True
+
+        return False
+    except Exception as e:
+        print("Helper Error: 'resident_is_identifiable' has encountered unexpected data.", str(e), help_request)
+        # Don't want to handle this by returning a bool value as this would imply
+        # that resident was not identifiable rather than resident data was unexpected.
+        raise e
 
 
 def clean_data(columns, data_frame):

--- a/lib_src/lib/usecase/create_help_requests.py
+++ b/lib_src/lib/usecase/create_help_requests.py
@@ -17,14 +17,19 @@ class CreateHelpRequest:
                     continue
                 response = self.gateway.create_help_request(help_request=help_request)
                 if "Error" in response:
+                    print("Gateway error was found within [CreateHelpRequestUseCase] use case.")
                     help_request['Error'] = response["Error"]
                     result["unsuccessful_help_requests"].append(help_request)
+                    # I question whether all this information ends up doing anything at all.
+                    print("Gateway error was appended to UC result.")
                 else:
                     result["created_help_request_ids"].append(response['Id'])
             except Exception as err:
                 help_request['Error'] = str(err)
                 exceptions.append(help_request)
                 print("[CreateHelpRequestUseCase] Failed to create help request", str(err), help_request)
+            
             if exceptions:
                 result["exceptions"] = exceptions
+                print("Exceptions list was appended to [CreateHelpRequestUseCase] result.")
         return result

--- a/lib_src/tests/gateways/test_here_to_help_api.py
+++ b/lib_src/tests/gateways/test_here_to_help_api.py
@@ -18,8 +18,19 @@ class TestCreateHelpRequest:
         requests_mock.register_uri(
             'POST',
             self.POST_HELP_REQUESTS_URL,
-            text='{"Id": "1"}')
+            text='{"Id": "1"}',
+            status_code=201)
         assert self.gateway.create_help_request(help_request={}) == {"Id": "1"}
+    
+    # The API promises 201, so it should be a 201 - we shouldn't be parsing json from any other response
+    def test_if_not_201_then_its_an_error(self, requests_mock):
+        requests_mock.register_uri(
+            'POST',
+            self.POST_HELP_REQUESTS_URL,
+            text='Error that mocks you, the programmer, when it\'s not logged',
+            status_code=409)
+        expected_exception = str(Exception("Failure within an API."))
+        assert self.gateway.create_help_request(help_request={}) == {"Error": expected_exception}
 
     def test_authentication_error_handling(self, requests_mock):
         requests_mock.register_uri(


### PR DESCRIPTION
# What:
- Added more logging to the problem area, where it was impossible to identify the exact location of one of the crashes.
- Changed the `eval(response.text)` into `response.json()` so that the code would fail in the predictable spot with the predictable message when returned JSON is invalid.
- Prevented the result from returning non object data when the response from the API is anything but 201.

# Why:
- Some CTAS records occasionally aren't getting ingested. The exact cause is unknown due to the lack of information. Logs show that the script was crashing, however the conditions could not be replicated neither locally, nor on staging environment. As such, the only course of action is left, which is to add more logging so upon the future failure the much needed information is available.

# Notes:
- The back-end API is promising to return 201 upon successful response, as such it's not an issue that we're not checking for all successful responses such as 200 or 204.
- The evidence so far shows that the there's a failure log within [CreateHelpRequestUseCase] with an error of: `"string indices must be integers"`. The suspicion is that the API has returned some failure message that could not be parsed by `eval` into object due to it not being JSON, and as such the code failed further down the line due to trying to access a string as if it was an object. **However**, looking at the API logs at the time of the script crash _(Oct 14 13:31)_ shows that there aren't any logs at all from 13:30 to 13:36. The 13:30 logs show no signs of failure. It's as if the API wasn't called at all - really weird. So I added more logging to unlikely places before the script calls the API as well.
- I ran all the tests & they passed. I also smoke tested the script against the staging API & it didn't run into any failures.