### PR TITLE
Auto find headers row

### DIFF
--- a/lib_src/lib/gateways/pygsheets_gateway.py
+++ b/lib_src/lib/gateways/pygsheets_gateway.py
@@ -11,25 +11,10 @@ class PygsheetsGateway:
         spreadsheet = self.gsheet_service.open_by_key(sheet_key)
         sheet = spreadsheet.worksheet('index', 0)  # CHANGEINCODE - finds first sheet instead
         
-        # Could extract header finding into a separate method called by UC, but that would introduce extra delay
-        # on an already tough timeout budget due to having to load up the sheet twice.
-        if(start_cell == 'auto'):
-            print(f'Attempting to find headers automatically.')
-        # If the headers are not within the first 10 rows, then something is seriously off with the sheet.
-        # It would't be a good idea to iterate over, say, 1'000 rows just to find out they're missing.
-        rawVals = sheet.get_all_values()[:10]
-
-        for index, row in enumerate(rawVals):
-            if(is_within_collection('Account ID', row) and is_within_collection('Forename', row) and is_within_collection('Surname', row)):
-                # Assuming that table starts at the 1st (A) column.
-                start_cell=f'A{index+1}'
-                print(start_cell , 'headers identified')
-                    break
-            else:
-                # Maybe reduce range to reduce logs?
-                print(index + 1, 'row - no headers')
-        else:
-            print(f'Using specified headers location: {start_cell}')
+        # start_cell can either be 'auto' or and actual cell like 'A3'. It's less confusing to avoid
+        # doing half processing ('auto' branching) within this method & doing the rest on another, hence 
+        # everything was moved to another method
+        start_cell = self.get_headers_row_start_cell(start_cell, sheet)
 
         data_frame = sheet.get_as_df(start=start_cell, parse_dates=True)  # CHANGEINCODE - different sheet loading style
         data_frame = data_frame.convert_dtypes()
@@ -48,3 +33,25 @@ class PygsheetsGateway:
         sheet1 = spreadsheet.worksheet('title', 'Sheet1')  # CHANGEINCODE - different worksheet pull
 
         spreadsheet.del_worksheet(sheet1)  # CHANGEINCODE - different worksheet delete
+
+    def get_headers_row_start_cell(self, start_cell, sheet):
+        # Could have UC call this method directly, but that would introduce extra delay
+        # on an already tough timeout budget due to having to load up the sheet twice.
+        if(start_cell == 'auto'):
+            print(f'Attempting to find headers automatically.')
+            # If the headers are not within the first 10 rows, then something is seriously off with the sheet.
+            # It would't be a good idea to iterate over, say, 1'000 rows just to find out they're missing.
+            rawVals = sheet.get_all_values()[:10]
+
+            for index, row in enumerate(rawVals):
+                if(is_within_collection('Account ID', row) and is_within_collection('Forename', row) and is_within_collection('Surname', row)):
+                    # Assuming that table starts at the 1st (A) column.
+                    start_cell=f'A{index+1}'
+                    print(start_cell , 'headers identified')
+                    return start_cell
+                else:
+                    # Maybe reduce range to reduce logs?
+                    print(index + 1, 'row - no headers')
+        else:
+            print(f'Using specified headers location: {start_cell}')
+            return start_cell

--- a/lib_src/lib/gateways/pygsheets_gateway.py
+++ b/lib_src/lib/gateways/pygsheets_gateway.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import pygsheets
+from ..helpers import is_within_collection
 
 class PygsheetsGateway:
     def __init__(self, key_file_location):
@@ -9,8 +10,24 @@ class PygsheetsGateway:
     def get_data_frame_from_sheet(self, sheet_key, start_cell):
         spreadsheet = self.gsheet_service.open_by_key(sheet_key)
         sheet = spreadsheet.worksheet('index', 0)  # CHANGEINCODE - finds first sheet instead
+        
+        # If the headers are not within the first 10 rows, then something is seriously off with the sheet.
+        # It would't be a good idea to iterate over, say, 1'000 rows just to find out they're missing.
+        rawVals = sheet.get_all_values()[:10]
+
+        start_cell=''
+        for index, row in enumerate(rawVals):
+            if(is_within_collection('Account ID', row) and is_within_collection('Forename', row) and is_within_collection('Surname', row)):
+                # Assuming that table starts at the 1st (A) column.
+                start_cell=f'A{index+1}'
+                print(start_cell , 'headers identified')
+            else:
+                # Maybe reduce range to reduce logs?
+                print(index + 1, 'row - no headers')
+
         data_frame = sheet.get_as_df(start=start_cell, parse_dates=True)  # CHANGEINCODE - different sheet loading style
         data_frame = data_frame.convert_dtypes()
+
         return data_frame  # returns dataframe
 
     def populate_spreadsheet(self, sheet_array, spreadsheet_key):

--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -93,3 +93,7 @@ def clean_data(columns, data_frame):
         data_frame[i] = data_frame[i].astype(str).str.strip().replace(r'nan', np.nan)
 
     return data_frame
+
+# No need to test this, as it's basically base python method
+def is_within_collection(value, collection):
+    return any(item == value for item in collection)

--- a/lib_src/lib/usecase/process_contact_tracing_calls.py
+++ b/lib_src/lib/usecase/process_contact_tracing_calls.py
@@ -63,7 +63,7 @@ class ProcessContactTracingCalls:
                 inbound_spread_sheet_id = file.get('id')
 
                 data_frame = self.pygsheet_gateway.get_data_frame_from_sheet(
-                    inbound_spread_sheet_id, 'A3')
+                    inbound_spread_sheet_id, 'auto')
 
                 if len(data_frame) < 3000:
                     data_frame = self.clean_data(data_frame=data_frame, excluded_ctas_ids=excluded_ctas_ids)

--- a/lib_src/tests/usecases/test_process_contact_tracing_calls.py
+++ b/lib_src/tests/usecases/test_process_contact_tracing_calls.py
@@ -125,7 +125,7 @@ def test_processing_new_power_bi_spreadsheet():
     ]
 
     assert fake_pygsheet_gateway.get_data_frame_from_sheet_called_with == [
-        ['inbound_folder_id', 'A3']]
+        ['inbound_folder_id', 'auto']]
 
     assert len(fake_pygsheet_gateway.populate_spreadsheet_called_with) == 2
 


### PR DESCRIPTION
# What:
- Code that determines the row of the CTAS headers in the given spreadsheet.

# Why:
- Because the sheets can be imported in 2 different formats, and we don't want to confuse the users by making them alter the exported spreadsheets manually.

# Notes:
- This piece of functionality was not unit-tested for the same reason why gsheets interaction wasn't tested by the previous maintainers - it's far from trivial to mock the spreadsheet datastructures or the client.