### PR TITLE
Fix the bug in manual date parsing, where if minutes the date comes out nonsensical

### DIFF
--- a/lib_src/lib/helpers.py
+++ b/lib_src/lib/helpers.py
@@ -6,6 +6,7 @@ import numpy as np
 
 
 def manual_parse(date_string):
+    date_string = re.sub(r"(\s\d\d:\d\d)(?=$|\s)", "\g<1>:00", date_string)
     date_numbers_string = re.findall(r'\d+', date_string)
     date_numbers_string = [date_portion.zfill(2) for date_portion in date_numbers_string]
     date_numbers_string = ''.join(date_numbers_string)

--- a/lib_src/tests/test_helpers.py
+++ b/lib_src/tests/test_helpers.py
@@ -1,7 +1,7 @@
+import datetime
 from faker import Faker
-from lib_src.lib.helpers import parse_date_of_birth, case_note_needs_an_update, resident_is_identifiable
+from lib_src.lib.helpers import parse_date_of_birth, case_note_needs_an_update, resident_is_identifiable, manual_parse
 from lib_src.lib.helpers import concatenate_address
-
 
 class TestAddressConcatenation:
 
@@ -331,3 +331,52 @@ class TestCaseResidentIsIdentifiable:
             "LastName": 'Zebra',
             "EmailAddress": 'mr@zebra.safari',
         })
+
+class TestManualParseMethodForDates:
+    def test_dmYHM_slash_date_returns_valid_date(self):
+        # arrange
+        test_date_1 = '09/11/2021 00:00'
+        expected_1 = datetime.datetime(2021,11,9,0,0)
+        
+        test_date_2 = '07/01/2021 18:57'
+        expected_2 = datetime.datetime(2021,1,7,18,57)
+
+        # act
+        parsed_date_str_1 = manual_parse(test_date_1)
+        parsed_date_str_2 = manual_parse(test_date_2)
+
+        # assert
+        assert (parsed_date_str_1 - expected_1).total_seconds() == 0
+        assert (parsed_date_str_2 - expected_2).total_seconds() == 0
+    
+    def test_dmY_slash_date_returns_valid_date(self):
+        # arrange
+        test_date_1 = '24/05/2022'
+        expected_1 = datetime.datetime(2022,5,24)
+        
+        test_date_2 = '18/03/2020'
+        expected_2 = datetime.datetime(2020,3,18)
+
+        # act
+        parsed_date_str_1 = manual_parse(test_date_1)
+        parsed_date_str_2 = manual_parse(test_date_2)
+
+        # assert
+        assert (parsed_date_str_1 - expected_1).total_seconds() == 0
+        assert (parsed_date_str_2 - expected_2).total_seconds() == 0
+    
+    def test_dmYHMS_slash_date_returns_valid_date(self):
+        # arrange
+        test_date_1 = '15/01/2022 00:00:00'
+        expected_1 = datetime.datetime(2022,1,15,0,0,0)
+        
+        test_date_2 = '25/12/2021 07:22:45'
+        expected_2 = datetime.datetime(2021,12,25,7,22,45)
+
+        # act
+        parsed_date_str_1 = manual_parse(test_date_1)
+        parsed_date_str_2 = manual_parse(test_date_2)
+
+        # assert
+        assert (parsed_date_str_1 - expected_1).total_seconds() == 0
+        assert (parsed_date_str_2 - expected_2).total_seconds() == 0


### PR DESCRIPTION
# What:
- A fix to manual date parsing of date format of dmYHM.

# Why:
- A date like "07/11/2021 00:00" gets incorrectly parsed into "711-02-02 10:00", which further down the lines makes all of the to-be-ingested records get skipped because the date tested was more than 14 days ago.
- New CTAS sheet extract has a different date format.

# Notes:
- Date formats of dmY and dmYHMS work, however the moment the S part gets omitted, we start getting silly results. So I added a piece of code that with the help of regex detects whether the date ends with hours and minutes... and if so, it adds on the 0th second on top of it so the parser's dmYHMS would trigger. I do the adding of seconds rather than removing of minutes and hours in order to preserve the given information.