### PR TITLE
Trigger the processing of City of London cases.

### DIFF
--- a/lib_src/lib/usecase/process_contact_tracing_calls.py
+++ b/lib_src/lib/usecase/process_contact_tracing_calls.py
@@ -91,7 +91,10 @@ class ProcessContactTracingCalls:
                         'data_frame': hackney_cases
                     }]
 
+                    print(f'Adding Hackney Cases: {len(hackney_cases)}')
                     self.add_contact_tracing_requests.execute(hackney_cases)
+                    print(f'Adding Hackney Cases: {len(city_cases)}')
+                    self.add_contact_tracing_requests.execute(city_cases)
 
                     today = dt.datetime.now().date().strftime('%Y-%m-%d')
 
@@ -116,7 +119,8 @@ class ProcessContactTracingCalls:
     @classmethod
     def get_city_cases(cls, data_frame):
         # print("[get_city_cases] Creating COL Case Dataframe")
-        city_data_frame = data_frame[data_frame['UTLA'] == 'City of London']
+        city_data_frame = data_frame[(data_frame['UTLA'] == 'CityofLondon') |
+                                     (data_frame['UTLA'] == 'City of London')]
         # print(city_data_frame)
         return city_data_frame
 

--- a/lib_src/tests/usecases/test_process_contact_tracing_calls.py
+++ b/lib_src/tests/usecases/test_process_contact_tracing_calls.py
@@ -128,8 +128,8 @@ def test_processing_new_power_bi_spreadsheet():
         ['inbound_folder_id', 'auto']]
 
     assert len(fake_pygsheet_gateway.populate_spreadsheet_called_with) == 2
-
-    assert len(fake_add_contact_tracing_requests.execute_called_with) == 1
+    # We're including City of London cases that were previously ignored
+    assert len(fake_add_contact_tracing_requests.execute_called_with) == 2
 
 
 def test_new_power_bi_spreadsheet_but_it_has_been_processed():


### PR DESCRIPTION
# What:
 - Made it so the non-Hackney cases could also be ingested.
 - Added additional condition to recognising City cases as this process is expected to support both PowerBI & NHS CTAS sheets.

# Why:
 - Something legal or loose obligation related making Hackney also pick up the neighbouring cases due to them getting ignored otherwise.
