### PR TITLE
Removed filter for ignoring CTAS Records without a phone number.

### DIFF
--- a/lib_src/lib/usecase/process_contact_tracing_calls.py
+++ b/lib_src/lib/usecase/process_contact_tracing_calls.py
@@ -93,7 +93,7 @@ class ProcessContactTracingCalls:
 
                     print(f'Adding Hackney Cases: {len(hackney_cases)}')
                     self.add_contact_tracing_requests.execute(hackney_cases)
-                    print(f'Adding Hackney Cases: {len(city_cases)}')
+                    print(f'Adding City Cases: {len(city_cases)}')
                     self.add_contact_tracing_requests.execute(city_cases)
 
                     today = dt.datetime.now().date().strftime('%Y-%m-%d')
@@ -127,9 +127,7 @@ class ProcessContactTracingCalls:
     def get_hackney_cases(self, data_frame):
         # print("[get_hackney_cases] Creating Hackney Case Dataframe")
         hack_data_frame = data_frame[data_frame['UTLA'] == 'Hackney']
-        hack_data_frame = hack_data_frame[(~hack_data_frame['Phone'].isna()) |
-                                          (~hack_data_frame['Phone2'].isna())]
-        # ensures there is at least one Phone Number
+        
         hack_data_frame = hack_data_frame[self.COLS]
         return hack_data_frame
 


### PR DESCRIPTION
# What:
 - Removed a filter that ignores CTAS Records with no phone number in either of the 2 phone number columns.

# Why:
 - This filter is a result of a requirement from the past that has become obsolete. Apparently, the Call Handlers now have access to something that allows them to schedule Hackney agent visits to homes of the people who's remote contact information is not available.

# Notes:
 - Also fixed typo in one of the logs. Made it so it's obvious how many cases belong to Hackney & how many to City. 